### PR TITLE
Correct Go Meta Linter warnings

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -25,7 +25,7 @@ func init() {
 	// path keys
 	for i := 0; i < len(pathKeys); i++ {
 		var key string
-		for i := 0; i < partsPerKey; i++ {
+		for j := 0; j < partsPerKey; j++ {
 			key += "/"
 			part := make([]byte, bytesPerPart)
 			if _, err := rand.Read(part); err != nil {
@@ -33,7 +33,7 @@ func init() {
 			}
 			key += string(part)
 		}
-		pathKeys[i] = string(key)
+		pathKeys[i] = key
 	}
 }
 

--- a/path_trie.go
+++ b/path_trie.go
@@ -113,11 +113,12 @@ type nodeStr struct {
 
 func (trie *PathTrie) walk(key string, walker WalkFunc) error {
 	if trie.value != nil {
-		walker(key, trie.value)
+		if err := walker(key, trie.value); err != nil {
+			return err
+		}
 	}
 	for part, child := range trie.children {
-		err := child.walk(key+part, walker)
-		if err != nil {
+		if err := child.walk(key+part, walker); err != nil {
 			return err
 		}
 	}

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -97,11 +97,12 @@ type nodeRune struct {
 
 func (trie *RuneTrie) walk(key string, walker WalkFunc) error {
 	if trie.value != nil {
-		walker(key, trie.value)
+		if err := walker(key, trie.value); err != nil {
+			return err
+		}
 	}
 	for r, child := range trie.children {
-		err := child.walk(key+string(r), walker)
-		if err != nil {
+		if err := child.walk(key+string(r), walker); err != nil {
 			return err
 		}
 	}

--- a/trie_test.go
+++ b/trie_test.go
@@ -1,6 +1,7 @@
 package trie
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -26,6 +27,11 @@ func TestRuneTrieWalk(t *testing.T) {
 	testTrieWalk(t, trie)
 }
 
+func TestRuneTrieWalkError(t *testing.T) {
+	trie := NewRuneTrie()
+	testTrieWalkError(t, trie)
+}
+
 // PathTrie
 
 func TestPathTrie(t *testing.T) {
@@ -46,6 +52,11 @@ func TestPathTrieRoot(t *testing.T) {
 func TestPathTrieWalk(t *testing.T) {
 	trie := NewPathTrie()
 	testTrieWalk(t, trie)
+}
+
+func TestPathTrieWalkError(t *testing.T) {
+	trie := NewPathTrie()
+	testTrieWalkError(t, trie)
 }
 
 func testTrie(t *testing.T, trie Trier) {
@@ -202,5 +213,35 @@ func testTrieWalk(t *testing.T, trie Trier) {
 		if walkedCount != 1 {
 			t.Errorf("expected key %s to be walked exactly once, got %v", key, walkedCount)
 		}
+	}
+}
+
+func testTrieWalkError(t *testing.T, trie Trier) {
+	table := map[string]interface{}{
+		"/L1/L2A":        1,
+		"/L1/L2B/L3A":    2,
+		"/L1/L2B/L3B/L4": 42,
+		"/L1/L2B/L3C":    4,
+		"/L1/L2C":        5,
+	}
+
+	walkerError := errors.New("walker error")
+	walked := 0
+
+	for key, value := range table {
+		trie.Put(key, value)
+	}
+	walker := func(key string, value interface{}) error {
+		if value == 42 {
+			return walkerError
+		}
+		walked++
+		return nil
+	}
+	if err := trie.Walk(walker); err != walkerError {
+		t.Errorf("expected walker error not generated, got %v", err)
+	}
+	if len(table) == walked {
+		t.Errorf("expected nodes walked < %d, got %d", len(table), walked)
 	}
 }


### PR DESCRIPTION
bench_test.go:36:23:warning: unnecessary conversion (unconvert)
bench_test.go:28::warning: declaration of "i" shadows declaration at ./bench_test.go:26 (vetshadow)