### PR TITLE
Add Node(), Value() and Children() to the Trier interface

### DIFF
--- a/path_trie.go
+++ b/path_trie.go
@@ -27,6 +27,16 @@ func (trie *PathTrie) Value() interface{} {
 	return trie.value
 }
 
+// Children returns the immediate children at the current trie node
+func (trie *PathTrie) Children() []Trier {
+	kids := make([]Trier, 0, len(trie.children))
+	for _, v := range trie.children {
+		kids = append(kids, v)
+	}
+
+	return kids
+}
+
 // Get returns the value stored at the given key. Returns nil for internal
 // nodes or for nodes with a value of nil.
 func (trie *PathTrie) Get(key string) interface{} {

--- a/path_trie.go
+++ b/path_trie.go
@@ -22,6 +22,11 @@ func NewPathTrie() *PathTrie {
 	}
 }
 
+// Value returns the value at the current trie node
+func (trie *PathTrie) Value() interface{} {
+	return trie.value
+}
+
 // Get returns the value stored at the given key. Returns nil for internal
 // nodes or for nodes with a value of nil.
 func (trie *PathTrie) Get(key string) interface{} {
@@ -95,6 +100,22 @@ func (trie *PathTrie) Delete(key string) bool {
 		}
 	}
 	return true // node (internal or not) existed and its value was nil'd
+}
+
+// Node returns the trie node with the given key.
+// Returns nil if the node with the given key is not found
+func (trie *PathTrie) Node(key string) Trier {
+	node := trie
+	for part, i := trie.segmenter(key, 0); ; part, i = trie.segmenter(key, i) {
+		node = node.children[part]
+		if node == nil {
+			return nil
+		}
+		if i == -1 {
+			break
+		}
+	}
+	return node
 }
 
 // Walk iterates over each key/value stored in the trie and calls the given

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -15,6 +15,16 @@ func NewRuneTrie() *RuneTrie {
 	}
 }
 
+// Children returns the immediate children at the current trie node
+func (trie *RuneTrie) Children() []Trier {
+	kids := make([]Trier, 0, len(trie.children))
+	for _, v := range trie.children {
+		kids = append(kids, v)
+	}
+
+	return kids
+}
+
 // Value returns the value at the current trie node
 func (trie *RuneTrie) Value() interface{} {
 	return trie.value

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -15,6 +15,11 @@ func NewRuneTrie() *RuneTrie {
 	}
 }
 
+// Value returns the value at the current trie node
+func (trie *RuneTrie) Value() interface{} {
+	return trie.value
+}
+
 // Get returns the value stored at the given key. Returns nil for internal
 // nodes or for nodes with a value of nil.
 func (trie *RuneTrie) Get(key string) interface{} {
@@ -79,6 +84,19 @@ func (trie *RuneTrie) Delete(key string) bool {
 		}
 	}
 	return true // node (internal or not) existed and its value was nil'd
+}
+
+// Node returns the trie node with the given key.
+// Returns nil if the node with the given key is not found
+func (trie *RuneTrie) Node(key string) Trier {
+	node := trie
+	for _, r := range key {
+		node = node.children[r]
+		if node == nil {
+			return nil
+		}
+	}
+	return node
 }
 
 // Walk iterates over each key/value stored in the trie and calls the given

--- a/trie.go
+++ b/trie.go
@@ -8,4 +8,5 @@ type Trier interface {
 	Walk(walker WalkFunc) error
 	Value() interface{}
 	Node(key string) Trier
+	Children() []Trier
 }

--- a/trie.go
+++ b/trie.go
@@ -6,4 +6,6 @@ type Trier interface {
 	Put(key string, value interface{}) bool
 	Delete(key string) bool
 	Walk(walker WalkFunc) error
+	Value() interface{}
+	Node(key string) Trier
 }


### PR DESCRIPTION
`Node(key string) Trier` will return a subtree of the trie
`Value() interface{}` will return the associated value for the current node
`Children() []Trier` will return the immediate children of the current node