### PR TITLE
feat: disk storage for RuneTrie and PathTrie

### DIFF
--- a/trie_storage.go
+++ b/trie_storage.go
@@ -1,0 +1,87 @@
+package trie
+
+import (
+	"encoding/gob"
+	"fmt"
+	"io"
+)
+
+type trieStorage struct {
+	// not storable on disk
+	// Segmenter StringSegmenter
+	Value    interface{}
+	Children map[string]*trieStorage
+}
+
+// Save stores the trie to file in a gob format.
+// does not store the Segmenter function
+func (trie *PathTrie) Save(out io.Writer) error {
+	ts := trie.toTrieStorage()
+	return gob.NewEncoder(out).Encode(&ts)
+}
+
+// Save stores a rune-trie
+func (trie *RuneTrie) Save(out io.Writer) error {
+	ts := trie.toTrieStorage()
+	return gob.NewEncoder(out).Encode(ts)
+}
+
+// LoadPathTrie reads a PathTrie from file (or io.Reader)
+func LoadPathTrie(in io.Reader) (*PathTrie, error) {
+	var ts trieStorage
+	err := gob.NewDecoder(in).Decode(&ts)
+	if err != nil {
+		return nil, err
+	}
+	return ts.toPathTrie(), nil
+}
+
+// LoadRuneTrie reads a RuneTrie from file (or any io.Reader)
+func LoadRuneTrie(in io.Reader) (*RuneTrie, error) {
+	var ts trieStorage
+	err := gob.NewDecoder(in).Decode(&ts)
+	if err != nil {
+		return nil, err
+	}
+	return ts.toRuneTrie()
+}
+
+func (ts *trieStorage) toPathTrie() *PathTrie {
+	trie := &PathTrie{segmenter: PathSegmenter, value: ts.Value, children: make(map[string]*PathTrie)}
+	for k, v := range ts.Children {
+		trie.children[k] = v.toPathTrie()
+	}
+	return trie
+}
+
+func (ts *trieStorage) toRuneTrie() (*RuneTrie, error) {
+	trie := &RuneTrie{value: ts.Value, children: make(map[rune]*RuneTrie)}
+	for k, v := range ts.Children {
+		rs := []rune(k)
+		if len(rs) != 1 {
+			return nil, fmt.Errorf("not a rune trie")
+		}
+		child, err := v.toRuneTrie()
+		if err != nil {
+			return nil, err
+		}
+		trie.children[rs[0]] = child
+	}
+	return trie, nil
+}
+
+func (trie *PathTrie) toTrieStorage() *trieStorage {
+	ts := &trieStorage{Value: trie.value, Children: make(map[string]*trieStorage)}
+	for k, v := range trie.children {
+		ts.Children[k] = v.toTrieStorage()
+	}
+	return ts
+}
+
+func (trie *RuneTrie) toTrieStorage() *trieStorage {
+	ts := &trieStorage{Value: trie.value, Children: make(map[string]*trieStorage)}
+	for k, v := range trie.children {
+		ts.Children[string(k)] = v.toTrieStorage()
+	}
+	return ts
+}

--- a/trie_test.go
+++ b/trie_test.go
@@ -1,6 +1,7 @@
 package trie
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 )
@@ -245,5 +246,57 @@ func testTrieWalkError(t *testing.T, trie Trier) {
 	}
 	if len(table) == walked {
 		t.Errorf("expected nodes walked < %d, got %d", len(table), walked)
+	}
+}
+
+func TestSaveRuneTrie(t *testing.T) {
+	tr := NewRuneTrie()
+	var buf []byte
+	buffer := bytes.NewBuffer(buf)
+
+	for i, k := range stringKeys {
+		tr.Put(k, i)
+	}
+	err := tr.Save(buffer)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	tr2, err := LoadRuneTrie(buffer)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	for i, k := range stringKeys {
+		if v := tr2.Get(k); v.(int) != i {
+			t.Errorf("Expected key >%s< to be >%d< but got >%v<", k, i, v)
+		}
+	}
+}
+
+func TestSavePathTrie(t *testing.T) {
+	tr := NewPathTrie()
+	var buf []byte
+	buffer := bytes.NewBuffer(buf)
+
+	for i, k := range stringKeys {
+		tr.Put(k, i)
+	}
+	err := tr.Save(buffer)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	tr2, err := LoadPathTrie(buffer)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	for i, k := range stringKeys {
+		if v := tr2.Get(k); v.(int) != i {
+			t.Errorf("Expected key >%s< to be >%d< but got >%v<", k, i, v)
+		}
 	}
 }


### PR DESCRIPTION
I need to do quite complicated pre-computations in order to get a trie. I could make some sort of half-way computation and store that, or preferably I could store the Trie immediately.

I made a simple draft of a what storage in gob would look like, without exporting the internals of PathTrie and RuneTrie.

What are your opinions?