### PR TITLE
Get all values in path to node

### DIFF
--- a/path_trie.go
+++ b/path_trie.go
@@ -39,7 +39,7 @@ func (trie *PathTrie) Get(key string) interface{} {
 }
 
 // GetPath returns all values stored at each node in the path from the root to
-// the given key. Does not return values for internal nodes or a nodes with a
+// the given key. Does not return values for internal nodes or for nodes with a
 // nil value.
 func (trie *PathTrie) GetPath(key string) []interface{} {
 	var values []interface{}

--- a/path_trie.go
+++ b/path_trie.go
@@ -38,6 +38,27 @@ func (trie *PathTrie) Get(key string) interface{} {
 	return node.value
 }
 
+// GetPath returns all values stored at each node in the path from the root to
+// the given key. Does not return values for internal nodes or a nodes with a
+// nil value.
+func (trie *PathTrie) GetPath(key string) []interface{} {
+	var values []interface{}
+	node := trie
+	for part, i := trie.segmenter(key, 0); ; part, i = trie.segmenter(key, i) {
+		node = node.children[part]
+		if node == nil {
+			return nil
+		}
+		if node.value != nil {
+			values = append(values, node.value)
+		}
+		if i == -1 {
+			break
+		}
+	}
+	return values
+}
+
 // Put inserts the value into the trie at the given key, replacing any
 // existing items. It returns true if the put adds a new value, false
 // if it replaces an existing value.

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -28,6 +28,24 @@ func (trie *RuneTrie) Get(key string) interface{} {
 	return node.value
 }
 
+// GetPath returns all values stored at each node in the path from the root to
+// the given key. Does not return values for internal nodes or a nodes with a
+// nil value.
+func (trie *RuneTrie) GetPath(key string) []interface{} {
+	var values []interface{}
+	node := trie
+	for _, r := range key {
+		node = node.children[r]
+		if node == nil {
+			return nil
+		}
+		if node.value != nil {
+			values = append(values, node.value)
+		}
+	}
+	return values
+}
+
 // Put inserts the value into the trie at the given key, replacing any
 // existing items. It returns true if the put adds a new value, false
 // if it replaces an existing value.

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -29,7 +29,7 @@ func (trie *RuneTrie) Get(key string) interface{} {
 }
 
 // GetPath returns all values stored at each node in the path from the root to
-// the given key. Does not return values for internal nodes or a nodes with a
+// the given key. Does not return values for internal nodes or for nodes with a
 // nil value.
 func (trie *RuneTrie) GetPath(key string) []interface{} {
 	var values []interface{}

--- a/trie.go
+++ b/trie.go
@@ -3,6 +3,7 @@ package trie
 // Trier exposes the Trie structure capabilities.
 type Trier interface {
 	Get(key string) interface{}
+	GetPath(key string) []interface{}
 	Put(key string, value interface{}) bool
 	Delete(key string) bool
 	Walk(walker WalkFunc) error

--- a/trie_test.go
+++ b/trie_test.go
@@ -115,10 +115,11 @@ func testTrie(t *testing.T, trie Trier) {
 	values := trie.GetPath(key)
 	if len(values) != len(expectValues) {
 		t.Errorf("expected %d values, got %d", len(expectValues), len(values))
-	}
-	for i := range expectValues {
-		if values[i] != expectValues[i] {
-			t.Errorf("expected value %v at position %d, got %v", expectValues[i], i, values[i])
+	} else {
+		for i := range expectValues {
+			if values[i] != expectValues[i] {
+				t.Errorf("expected value %v at position %d, got %v", expectValues[i], i, values[i])
+			}
 		}
 	}
 

--- a/trie_test.go
+++ b/trie_test.go
@@ -2,6 +2,7 @@ package trie
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -99,6 +100,25 @@ func testTrie(t *testing.T, trie Trier) {
 	for _, c := range cases {
 		if value := trie.Get(c.key); value != c.value {
 			t.Errorf("expected key %s to have value %v, got %v", c.key, c.value, value)
+		}
+	}
+
+	// get path
+	key := cases[6].key
+	var expectValues []interface{}
+	for _, c := range cases {
+		// If c.key is a prefix of key, then expect c.value.
+		if strings.HasPrefix(key, c.key) {
+			expectValues = append(expectValues, c.value)
+		}
+	}
+	values := trie.GetPath(key)
+	if len(values) != len(expectValues) {
+		t.Errorf("expected %d values, got %d", len(expectValues), len(values))
+	}
+	for i := range expectValues {
+		if values[i] != expectValues[i] {
+			t.Errorf("expected value %v at position %d, got %v", expectValues[i], i, values[i])
 		}
 	}
 


### PR DESCRIPTION
I have use cases where it is necessary to get not just the requested value, but all values in the path to the requested node.  This PR allows me to do that in a single call to `GetPath`, instead of having to make repeated calls for each segment of a key.