### PR TITLE
GetPath gets all values in path from root to node

### DIFF
--- a/path_trie.go
+++ b/path_trie.go
@@ -18,7 +18,6 @@ type PathTrie struct {
 func NewPathTrie() *PathTrie {
 	return &PathTrie{
 		segmenter: PathSegmenter,
-		children:  make(map[string]*PathTrie),
 	}
 }
 
@@ -70,6 +69,9 @@ func (trie *PathTrie) Put(key string, value interface{}) bool {
 	for part, i := trie.segmenter(key, 0); ; part, i = trie.segmenter(key, i) {
 		child, _ := node.children[part]
 		if child == nil {
+			if node.children == nil {
+				node.children = map[string]*PathTrie{}
+			}
 			child = NewPathTrie()
 			node.children[part] = child
 		}
@@ -110,8 +112,13 @@ func (trie *PathTrie) Delete(key string) bool {
 			parent := path[i].node
 			part := path[i].part
 			delete(parent.children, part)
-			if parent.value != nil || !parent.isLeaf() {
-				// parent has a value or has other children, stop
+			if !parent.isLeaf() {
+				// parent has other children, stop
+				break
+			}
+			parent.children = nil
+			if parent.value != nil {
+				// parent has a value, stop
 				break
 			}
 		}

--- a/path_trie.go
+++ b/path_trie.go
@@ -38,6 +38,28 @@ func (trie *PathTrie) Get(key string) interface{} {
 	return node.value
 }
 
+// GetPath returns all values stored in the path from the root to the node at
+// the given key. Does not return values for internal nodes or for nodes with a
+// value of nil. Returns a boolean indicating if there was a value stored at
+// the full key.
+func (trie *PathTrie) GetPath(key string) ([]interface{}, bool) {
+	var values []interface{}
+	node := trie
+	for part, i := trie.segmenter(key, 0); ; part, i = trie.segmenter(key, i) {
+		node = node.children[part]
+		if node == nil {
+			return values, false
+		}
+		if node.value != nil {
+			values = append(values, node.value)
+		}
+		if i == -1 {
+			break
+		}
+	}
+	return values, true
+}
+
 // Put inserts the value into the trie at the given key, replacing any
 // existing items. It returns true if the put adds a new value, false
 // if it replaces an existing value.

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -10,9 +10,7 @@ type RuneTrie struct {
 
 // NewRuneTrie allocates and returns a new *RuneTrie.
 func NewRuneTrie() *RuneTrie {
-	return &RuneTrie{
-		children: make(map[rune]*RuneTrie),
-	}
+	return new(RuneTrie)
 }
 
 // Get returns the value stored at the given key. Returns nil for internal
@@ -57,7 +55,10 @@ func (trie *RuneTrie) Put(key string, value interface{}) bool {
 	for _, r := range key {
 		child, _ := node.children[r]
 		if child == nil {
-			child = NewRuneTrie()
+			if node.children == nil {
+				node.children = map[rune]*RuneTrie{}
+			}
+			child = new(RuneTrie)
 			node.children[r] = child
 		}
 		node = child
@@ -84,15 +85,21 @@ func (trie *RuneTrie) Delete(key string) bool {
 	}
 	// delete the node value
 	node.value = nil
-	// if leaf, remove it from its parent's children map. Repeat for ancestor path.
+	// if leaf, remove it from its parent's children map. Repeat for ancestor
+	// path.
 	if node.isLeaf() {
 		// iterate backwards over path
 		for i := len(key) - 1; i >= 0; i-- {
 			parent := path[i].node
 			r := path[i].r
 			delete(parent.children, r)
-			if parent.value != nil || !parent.isLeaf() {
-				// parent has a value or has other children, stop
+			if !parent.isLeaf() {
+				// parent has other children, stop
+				break
+			}
+			parent.children = nil
+			if parent.value != nil {
+				// parent has a value, stop
 				break
 			}
 		}

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -28,6 +28,25 @@ func (trie *RuneTrie) Get(key string) interface{} {
 	return node.value
 }
 
+// GetPath returns all values stored in the path from the root to the node at
+// the given key. Does not return values for internal nodes or for nodes with a
+// value of nil. Returns a boolean indicating if there was a value stored at
+// the full key.
+func (trie *RuneTrie) GetPath(key string) ([]interface{}, bool) {
+	var values []interface{}
+	node := trie
+	for _, r := range key {
+		node = node.children[r]
+		if node == nil {
+			return values, false
+		}
+		if node.value != nil {
+			values = append(values, node.value)
+		}
+	}
+	return values, true
+}
+
 // Put inserts the value into the trie at the given key, replacing any
 // existing items. It returns true if the put adds a new value, false
 // if it replaces an existing value.

--- a/trie.go
+++ b/trie.go
@@ -3,6 +3,7 @@ package trie
 // Trier exposes the Trie structure capabilities.
 type Trier interface {
 	Get(key string) interface{}
+	GetPath(key string) ([]interface{}, bool)
 	Put(key string, value interface{}) bool
 	Delete(key string) bool
 	Walk(walker WalkFunc) error

--- a/trie_test.go
+++ b/trie_test.go
@@ -2,6 +2,7 @@ package trie
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -99,6 +100,29 @@ func testTrie(t *testing.T, trie Trier) {
 	for _, c := range cases {
 		if value := trie.Get(c.key); value != c.value {
 			t.Errorf("expected key %s to have value %v, got %v", c.key, c.value, value)
+		}
+	}
+
+	// get path
+	key := cases[6].key
+	var expectValues []interface{}
+	for _, c := range cases {
+		// If c.key is a prefix of key, then expect c.value.
+		if strings.HasPrefix(key, c.key) {
+			expectValues = append(expectValues, c.value)
+		}
+	}
+	values, ok := trie.GetPath(key)
+	if !ok {
+		t.Errorf("expected value for key")
+	}
+	if len(values) != len(expectValues) {
+		t.Errorf("expected %d values, got %d", len(expectValues), len(values))
+	} else {
+		for i := range expectValues {
+			if values[i] != expectValues[i] {
+				t.Errorf("expected value %v at position %d, got %v", expectValues[i], i, values[i])
+			}
 		}
 	}
 


### PR DESCRIPTION
I have use cases where it is necessary to get not just the requested value, but all values in the path to the requested node.  This PR allows me to do that in a single call to `GetPath`, instead of having to make repeated calls for each segment of a key.

I think this may be a reasonable addition, since my use is likely not unique: I store [OID](https://en.wikipedia.org/wiki/Object_identifier)-like keys in the trie.  When I retrieve the value for a specific key, I also want to get other information associated with the key, which is part of the key's hierarchy.

FYI - This package is being used in production code that requires hundreds or thousands of lookups per second, and performs beautifully.