### PR TITLE
Add WalkPath function to walk each key/value in path from root to given key

### DIFF
--- a/rune_trie.go
+++ b/rune_trie.go
@@ -96,6 +96,30 @@ func (trie *RuneTrie) Walk(walker WalkFunc) error {
 	return trie.walk("", walker)
 }
 
+// WalkPath iterates over each key/value in the path in trie from the root to
+// the node at the given key, calling the given walker function for each
+// key/value. If the walker function returns an error, the walk is aborted.
+func (trie *RuneTrie) WalkPath(key string, walker WalkFunc) error {
+	// Get root value if one exists.
+	if trie.value != nil {
+		if err := walker("", trie.value); err != nil {
+			return err
+		}
+	}
+
+	for i, r := range key {
+		if trie = trie.children[r]; trie == nil {
+			return nil
+		}
+		if trie.value != nil {
+			if err := walker(string(key[0:i+1]), trie.value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // RuneTrie node and the rune key of the child the path descends into.
 type nodeRune struct {
 	node *RuneTrie

--- a/trie.go
+++ b/trie.go
@@ -6,4 +6,5 @@ type Trier interface {
 	Put(key string, value interface{}) bool
 	Delete(key string) bool
 	Walk(walker WalkFunc) error
+	WalkPath(key string, walker WalkFunc) error
 }

--- a/trie_test.go
+++ b/trie_test.go
@@ -32,6 +32,16 @@ func TestRuneTrieWalkError(t *testing.T) {
 	testTrieWalkError(t, trie)
 }
 
+func TestRuneTrieWalkPath(t *testing.T) {
+	trie := NewRuneTrie()
+	testTrieWalkPath(t, trie)
+}
+
+func TestRuneTrieWalkPathError(t *testing.T) {
+	trie := NewRuneTrie()
+	testTrieWalkPathError(t, trie)
+}
+
 // PathTrie
 
 func TestPathTrie(t *testing.T) {
@@ -57,6 +67,16 @@ func TestPathTrieWalk(t *testing.T) {
 func TestPathTrieWalkError(t *testing.T) {
 	trie := NewPathTrie()
 	testTrieWalkError(t, trie)
+}
+
+func TestPathTrieWalkPath(t *testing.T) {
+	trie := NewPathTrie()
+	testTrieWalkPath(t, trie)
+}
+
+func TestPathTrieWalkPathError(t *testing.T) {
+	trie := NewPathTrie()
+	testTrieWalkPathError(t, trie)
 }
 
 func testTrie(t *testing.T, trie Trier) {
@@ -245,5 +265,149 @@ func testTrieWalkError(t *testing.T, trie Trier) {
 	}
 	if len(table) == walked {
 		t.Errorf("expected nodes walked < %d, got %d", len(table), walked)
+	}
+}
+
+func testTrieWalkPath(t *testing.T, trie Trier) {
+	table := map[string]interface{}{
+		"fish":             0,
+		"/cat":             1,
+		"/dog":             2,
+		"/cats":            3,
+		"/caterpillar":     4,
+		"/notes":           30,
+		"/notes/new":       31,
+		"/notes/new/noise": 32,
+	}
+	// key -> times walked
+	walked := make(map[string]int)
+	for key := range table {
+		walked[key] = 0
+	}
+
+	for key, value := range table {
+		if isNew := trie.Put(key, value); !isNew {
+			t.Errorf("expected key %s to be missing", key)
+		}
+	}
+
+	walker := func(key string, value interface{}) error {
+		// value for each walked key is correct
+		if value != table[key] {
+			t.Errorf("expected key %s to have value %v, got %v", key, table[key], value)
+		}
+		walked[key]++
+		return nil
+	}
+	if err := trie.WalkPath("/notes/new/noise", walker); err != nil {
+		t.Errorf("expected error nil, got %v", err)
+	}
+
+	// expect each key/value in path walked exactly once, and not other keys
+	for key, walkedCount := range walked {
+		switch key {
+		case "/notes", "/notes/new", "/notes/new/noise":
+			if walkedCount != 1 {
+				t.Errorf("expected key %s to be walked exactly once, got %v", key, walkedCount)
+			}
+		default:
+			if walkedCount != 0 {
+				t.Errorf("expected key %s to not be walked, got %v", key, walkedCount)
+			}
+		}
+	}
+
+	for key := range table {
+		walked[key] = 0
+	}
+	if err := trie.WalkPath("/notes/new/nose", walker); err != nil {
+		t.Errorf("expected error nil, got %v", err)
+	}
+	// expect each key/value in path walked exactly once, and not other keys
+	for key, walkedCount := range walked {
+		switch key {
+		case "/notes", "/notes/new":
+			if walkedCount != 1 {
+				t.Errorf("expected key %s to be walked exactly once, got %v", key, walkedCount)
+			}
+		default:
+			if walkedCount != 0 {
+				t.Errorf("expected key %s to not be walked, got %v", key, walkedCount)
+			}
+		}
+	}
+
+	var foundRoot bool
+	trie.Put("", "ROOT")
+	trie.WalkPath("/notes/new/noise", func(key string, value interface{}) error {
+		if key == "" && value == "ROOT" {
+			foundRoot = true
+		}
+		return nil
+	})
+	if !foundRoot {
+		t.Error("did not find root")
+	}
+}
+
+func testTrieWalkPathError(t *testing.T, trie Trier) {
+	table := map[string]interface{}{
+		"/L1/L2A":        1,
+		"/L1/L2A/L3B":    99,
+		"/L1/L2A/L3B/L4": 2,
+		"/L1/L2B/L3B":    3,
+		"/L1/L2C":        4,
+	}
+
+	walkerError := errors.New("walker error")
+
+	walked := make(map[string]int)
+	for key := range table {
+		walked[key] = 0
+	}
+
+	for key, value := range table {
+		trie.Put(key, value)
+	}
+	walker := func(key string, value interface{}) error {
+		if value == 99 {
+			return walkerError
+		}
+		walked[key]++
+		return nil
+	}
+	if err := trie.WalkPath("/L1/L2A/L3B", walker); err != walkerError {
+		t.Errorf("expected walker error, got %v", err)
+	}
+	// expect each key/value in path, up to error and not including key with
+	// value 99, walked exactly once, and not other keys
+	var walkedTotal int
+	for key, walkedCount := range walked {
+		switch key {
+		case "/L1/L2A":
+			if walkedCount != 1 {
+				t.Errorf("expected key %s to be walked exactly once, got %v", key, walkedCount)
+			}
+			walkedTotal++
+		default:
+			if walkedCount != 0 {
+				t.Errorf("expected key %s to not be walked, got %v", key, walkedCount)
+			}
+		}
+	}
+	if walkedTotal != 1 {
+		t.Errorf("expected 1 nodes walked, got %d", walkedTotal)
+	}
+
+	rootError := errors.New("error at root")
+	trie.Put("", "ROOT")
+	err := trie.WalkPath("/L1/L2A/L3B/L4", func(key string, value interface{}) error {
+		if key == "" && value == "ROOT" {
+			return rootError
+		}
+		return nil
+	})
+	if err != rootError {
+		t.Errorf("expected %s, got %s", rootError, err)
 	}
 }


### PR DESCRIPTION
This PR also contains a fix to `PathTrie`:  It was not storing values for empty key "" in the root node, but rather creating a new child of root at "".