### PR TITLE
Fixed PathTrie not storing value in root node

### DIFF
--- a/path_trie.go
+++ b/path_trie.go
@@ -25,13 +25,10 @@ func NewPathTrie() *PathTrie {
 // nodes or for nodes with a value of nil.
 func (trie *PathTrie) Get(key string) interface{} {
 	node := trie
-	for part, i := trie.segmenter(key, 0); ; part, i = trie.segmenter(key, i) {
+	for part, i := trie.segmenter(key, 0); part != ""; part, i = trie.segmenter(key, i) {
 		node = node.children[part]
 		if node == nil {
 			return nil
-		}
-		if i == -1 {
-			break
 		}
 	}
 	return node.value
@@ -44,7 +41,7 @@ func (trie *PathTrie) Get(key string) interface{} {
 // be distinguishable and will not be included in Walks.
 func (trie *PathTrie) Put(key string, value interface{}) bool {
 	node := trie
-	for part, i := trie.segmenter(key, 0); ; part, i = trie.segmenter(key, i) {
+	for part, i := trie.segmenter(key, 0); part != ""; part, i = trie.segmenter(key, i) {
 		child, _ := node.children[part]
 		if child == nil {
 			if node.children == nil {
@@ -54,9 +51,6 @@ func (trie *PathTrie) Put(key string, value interface{}) bool {
 			node.children[part] = child
 		}
 		node = child
-		if i == -1 {
-			break
-		}
 	}
 	// does node have an existing value?
 	isNewVal := node.value == nil
@@ -70,15 +64,12 @@ func (trie *PathTrie) Put(key string, value interface{}) bool {
 func (trie *PathTrie) Delete(key string) bool {
 	var path []nodeStr // record ancestors to check later
 	node := trie
-	for part, i := trie.segmenter(key, 0); ; part, i = trie.segmenter(key, i) {
+	for part, i := trie.segmenter(key, 0); part != ""; part, i = trie.segmenter(key, i) {
 		path = append(path, nodeStr{part: part, node: node})
 		node = node.children[part]
 		if node == nil {
 			// node does not exist
 			return false
-		}
-		if i == -1 {
-			break
 		}
 	}
 	// delete the node value

--- a/trie_test.go
+++ b/trie_test.go
@@ -20,6 +20,15 @@ func TestRuneTrieNilBehavior(t *testing.T) {
 func TestRuneTrieRoot(t *testing.T) {
 	trie := NewRuneTrie()
 	testTrieRoot(t, trie)
+
+	trie = NewRuneTrie()
+	if !trie.isLeaf() {
+		t.Error("root of empty tree should be leaf")
+	}
+	trie.Put("", "root")
+	if !trie.isLeaf() {
+		t.Error("root should not have children, only value")
+	}
 }
 
 func TestRuneTrieWalk(t *testing.T) {
@@ -47,6 +56,15 @@ func TestPathTrieNilBehavior(t *testing.T) {
 func TestPathTrieRoot(t *testing.T) {
 	trie := NewPathTrie()
 	testTrieRoot(t, trie)
+
+	trie = NewPathTrie()
+	if !trie.isLeaf() {
+		t.Error("root of empty tree should be leaf")
+	}
+	trie.Put("", "root")
+	if !trie.isLeaf() {
+		t.Error("root should not have children, only value")
+	}
 }
 
 func TestPathTrieWalk(t *testing.T) {
@@ -177,6 +195,7 @@ func testTrieRoot(t *testing.T, trie Trier) {
 
 func testTrieWalk(t *testing.T, trie Trier) {
 	table := map[string]interface{}{
+		"":             -1,
 		"fish":         0,
 		"/cat":         1,
 		"/dog":         2,


### PR DESCRIPTION
`PathTrie` was not storing the value for and empty key in the root node, but was creating a new child of root.  This PR fixes this and includes a unit test to confirm.