### PR TITLE
Fix invalid memory address or nil pointer dereference  when  deleting rune key 

### DIFF
--- a/rune_trie.go
+++ b/rune_trie.go
@@ -71,9 +71,9 @@ func (trie *RuneTrie) Delete(key string) bool {
 	if node.isLeaf() {
 		// iterate backwards over path
 		for i := len(key) - 1; i >= 0; i-- {
-      if path[i].node == nil {
-        continue
-      }
+			if path[i].node == nil {
+				continue
+			}
 			parent := path[i].node
 			r := path[i].r
 			delete(parent.children, r)

--- a/rune_trie.go
+++ b/rune_trie.go
@@ -71,6 +71,9 @@ func (trie *RuneTrie) Delete(key string) bool {
 	if node.isLeaf() {
 		// iterate backwards over path
 		for i := len(key) - 1; i >= 0; i-- {
+      if path[i].node == nil {
+        continue
+      }
 			parent := path[i].node
 			r := path[i].r
 			delete(parent.children, r)

--- a/trie_test.go
+++ b/trie_test.go
@@ -125,6 +125,8 @@ func testTrie(t *testing.T, trie Trier) {
 		{"/caterpillar", 4},
 		{"/cat/gideon", 5},
 		{"/cat/giddy", 6},
+		{"مسار", 7},
+		{"這是第三個值", 8},
 	}
 
 	// get missing keys


### PR DESCRIPTION
when trying to delete rune key for example 
```go 
trie.Put("احمد", "محمد")
trie.Delete("محمد") // panic
```
```
panic: runtime error: invalid memory address or nil pointer dereference
e
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x47e98e]

goroutine 1 [running]:
github.com/dghubble/trie.(*RuneTrie).Delete(0xc00000c030, {0x495405, 0x8})
        /home/hefni101/go/pkg/mod/github.com/dghubble/trie@v0.0.0-2021
1002190126-ca25329b35c6/rune_trie.go:76 +0x1ae
```


