### PR TITLE
Use a centrally managed GitHub Workflow for go tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,26 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - main
-  pull_request:
 jobs:
-  build:
-    name: go
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.17', '1.18', '1.19']
-    steps:
-      - name: setup
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{matrix.go}}
-
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: test
-        run: make
-
+  go:
+    uses: dghubble/.github/.github/workflows/golang-library.yaml@main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Trie [![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/trie.svg)](https://pkg.go.dev/github.com/dghubble/trie) [![Workflow](https://github.com/dghubble/trie/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/trie/actions/workflows/test.yaml?query=branch%3Amain) [![Coverage](https://gocover.io/_badge/github.com/dghubble/trie)](https://gocover.io/github.com/dghubble/trie) [![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble) [![Twitter](https://img.shields.io/badge/twitter-follow-1da1f2?logo=twitter)](https://twitter.com/dghubble)
+# Trie
+[![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/trie.svg)](https://pkg.go.dev/github.com/dghubble/trie)
+[![Workflow](https://github.com/dghubble/trie/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/trie/actions/workflows/test.yaml?query=branch%3Amain)
+[![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble)
+[![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@dghubble)
 
 Package `trie` implements rune-wise and path-wise [Tries](https://en.wikipedia.org/wiki/Trie) optimized for `Get` performance and to allocate 0 bytes of heap memory (i.e. garbage) per `Get`.
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/dghubble/trie
 
-go 1.17
+go 1.19


### PR DESCRIPTION
* Use GitHub Workflow from https://github.com/dghubble/.github
* Test against Go v1.19 and v1.20