### PR TITLE
Use cross-platform path separator

### DIFF
--- a/common.go
+++ b/common.go
@@ -1,6 +1,7 @@
 package trie
 
 import (
+	"path/filepath"
 	"strings"
 )
 
@@ -22,7 +23,7 @@ func PathSegmenter(path string, start int) (segment string, next int) {
 	if len(path) == 0 || start < 0 || start > len(path)-1 {
 		return "", -1
 	}
-	end := strings.IndexRune(path[start+1:], '/') // next '/' after 0th rune
+	end := strings.IndexRune(path[start+1:], filepath.Separator) // next '/' after 0th rune
 	if end == -1 {
 		return path[start:], -1
 	}


### PR DESCRIPTION
Observed when using this lib in Windows runtime, where paths are segmented with `\`
