### PR TITLE
Add Generics Support, More Idiomatic Go

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -43,7 +43,7 @@ func init() {
 // string keys
 
 func BenchmarkRuneTriePutStringKey(b *testing.B) {
-	trie := NewRuneTrie()
+	trie := NewRuneTrie[int]()
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -52,7 +52,7 @@ func BenchmarkRuneTriePutStringKey(b *testing.B) {
 }
 
 func BenchmarkRuneTrieGetStringKey(b *testing.B) {
-	trie := NewRuneTrie()
+	trie := NewRuneTrie[int]()
 	for i := 0; i < b.N; i++ {
 		trie.Put(stringKeys[i%len(stringKeys)], i)
 	}
@@ -66,7 +66,7 @@ func BenchmarkRuneTrieGetStringKey(b *testing.B) {
 // path keys
 
 func BenchmarkRuneTriePutPathKey(b *testing.B) {
-	trie := NewRuneTrie()
+	trie := NewRuneTrie[int]()
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -75,7 +75,7 @@ func BenchmarkRuneTriePutPathKey(b *testing.B) {
 }
 
 func BenchmarkRuneTrieGetPathKey(b *testing.B) {
-	trie := NewRuneTrie()
+	trie := NewRuneTrie[int]()
 	for i := 0; i < b.N; i++ {
 		trie.Put(pathKeys[i%len(pathKeys)], i)
 	}
@@ -92,7 +92,7 @@ func BenchmarkRuneTrieGetPathKey(b *testing.B) {
 // string keys
 
 func BenchmarkPathTriePutStringKey(b *testing.B) {
-	trie := NewPathTrie()
+	trie := NewPathTrie[int]()
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -101,7 +101,7 @@ func BenchmarkPathTriePutStringKey(b *testing.B) {
 }
 
 func BenchmarkPathTrieGetStringKey(b *testing.B) {
-	trie := NewPathTrie()
+	trie := NewPathTrie[int]()
 	for i := 0; i < b.N; i++ {
 		trie.Put(stringKeys[i%len(stringKeys)], i)
 	}
@@ -115,7 +115,7 @@ func BenchmarkPathTrieGetStringKey(b *testing.B) {
 // path keys
 
 func BenchmarkPathTriePutPathKey(b *testing.B) {
-	trie := NewPathTrie()
+	trie := NewPathTrie[int]()
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -124,7 +124,7 @@ func BenchmarkPathTriePutPathKey(b *testing.B) {
 }
 
 func BenchmarkPathTrieGetPathKey(b *testing.B) {
-	trie := NewPathTrie()
+	trie := NewPathTrie[int]()
 	for i := 0; i < b.N; i++ {
 		trie.Put(pathKeys[i%len(pathKeys)], i)
 	}

--- a/common.go
+++ b/common.go
@@ -6,7 +6,7 @@ import (
 
 // WalkFunc defines some action to take on the given key and value during
 // a Trie Walk. Returning a non-nil error will terminate the Walk.
-type WalkFunc func(key string, value interface{}) error
+type WalkFunc[T any] func(key string, value T) error
 
 // StringSegmenter takes a string key with a starting index and returns
 // the first segment after the start and the ending index. When the end is
@@ -27,4 +27,11 @@ func PathSegmenter(path string, start int) (segment string, next int) {
 		return path[start:], -1
 	}
 	return path[start : start+end+1], start + end + 1
+}
+
+// zeroValueOfT returns the zero value of type T. For example, the
+// empty string ("") for string, 0 for int, nil for pointers, etc.
+func zeroValueOfT[T any]() T {
+	var t T
+	return t
 }

--- a/segmenter_test.go
+++ b/segmenter_test.go
@@ -99,15 +99,14 @@ func TestCustomPathSegmenter(t *testing.T) {
 		".a.b.c.d.e": false,
 	}
 
-	tie := NewPathTrieWithConfig(&PathTrieConfig{Segmenter: testPathSegmenterDot})
+	tie := NewPathTrie(WithSegmenter[any](testPathSegmenterDot))
 	for k := range depthTest {
 		tie.Put(k, true)
 	}
 
 	for k := range depthTest {
-		tie.WalkPath(k, func(k string, v interface{}) error {
-			out := tie.Get(k)
-			if out != nil {
+		tie.WalkPath(k, func(k string, _ any) error {
+			if _, ok := tie.Get(k); ok {
 				depthTest[k] = true
 			}
 			return nil

--- a/trie.go
+++ b/trie.go
@@ -1,10 +1,10 @@
 package trie
 
-// Trier exposes the Trie structure capabilities.
-type Trier interface {
-	Get(key string) interface{}
-	Put(key string, value interface{}) bool
+// Trie exposes the Trie structure capabilities.
+type Trie[T any] interface {
+	Get(key string) (T, bool)
+	Put(key string, value T) bool
 	Delete(key string) bool
-	Walk(walker WalkFunc) error
-	WalkPath(key string, walker WalkFunc) error
+	Walk(walker WalkFunc[T]) error
+	WalkPath(key string, walker WalkFunc[T]) error
 }


### PR DESCRIPTION
## Add Generics Support, More Idiomatic Go

- Simplifies code for users of this package (avoids type assertions at runtime) and helps prevent runtime `panic`s due to wrong type-assertions
- Made lookup function e.g. `Get()` more idiomatic by returning true/false for whether item was found
- Makes the individual trie types private e.g. `PathTrie --> pathTrie`, `RuneTrie --> runeTrie` and has constructors return the interface (better encapsulation)
- Makes the following NOT true anymore for either implementation: `Internal nodes have nil values so stored nil values cannot be distinguished and are excluded from walks.`, nil values can now be stored and distinguished from empty nodes.
- Other misc. cosmetic changes.

Note that if existing users want to maintain the ability to store multiple different types of data in the trie they can still use the constructors with type `any`. e.g. before `NewPathTrie()`, now `NewPathTrie[any]()`. While most users of this library will now be able to do `NewPathTrie[string]()` when they only ever expect to store strings, or `NewPathTrie[*customStruct]()`, and so on...

### UX

#### Before:

```
trie := NewPathTrie()

trie.Put("/hello/world", 27)

value := trie.Get("/hello/world")

// must do a type assertion before using value (cumbersome)
if intValue, ok := value.(int); ok {
    sum += intValue
}

// or risk a runtime panic by skipping the check part
otherSum += value.(int)
```

#### After:

```
trie := NewPathTrie[int]()

trie.Put("/hello/world", 27)

// value returned from lookup can be used directly
if value, ok := trie.Get("/hello/world"); ok {
    sum += value
}
```

### Benchmark (TL;DR; No Changes)

#### Before:

```
✔ ~/go/src/github.com/dghubble/trie [main|✔]
10:15 $ go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/dghubble/trie
cpu: Apple M1 Pro
BenchmarkRuneTriePutStringKey-8   	 3474247	       323.8 ns/op	       9 B/op	       1 allocs/op
BenchmarkRuneTrieGetStringKey-8   	 3813277	       317.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneTriePutPathKey-8     	 3481916	       337.2 ns/op	       9 B/op	       1 allocs/op
BenchmarkRuneTrieGetPathKey-8     	 3644137	       331.9 ns/op	       0 B/op	       0 allocs/op
BenchmarkPathTriePutStringKey-8   	28855054	        40.92 ns/op	       8 B/op	       1 allocs/op
BenchmarkPathTrieGetStringKey-8   	39185912	        30.34 ns/op	       0 B/op	       0 allocs/op
BenchmarkPathTriePutPathKey-8     	16460866	        71.89 ns/op	       8 B/op	       1 allocs/op
BenchmarkPathTrieGetPathKey-8     	19688133	        60.69 ns/op	       0 B/op	       0 allocs/op
BenchmarkPathSegmenter-8          	45136537	        26.25 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/dghubble/trie	18.762s
```

#### After

```
✔ ~/go/src/github.com/adrianosela/trie [main|✔]
10:17 $ go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/dghubble/trie
cpu: Apple M1 Pro
BenchmarkRuneTriePutStringKey-8   	 3492538	       324.1 ns/op	       9 B/op	       1 allocs/op
BenchmarkRuneTrieGetStringKey-8   	 3845990	       306.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkRuneTriePutPathKey-8     	 3444878	       341.2 ns/op	       9 B/op	       1 allocs/op
BenchmarkRuneTrieGetPathKey-8     	 3705607	       322.3 ns/op	       0 B/op	       0 allocs/op
BenchmarkPathTriePutStringKey-8   	30349173	        38.81 ns/op	       8 B/op	       1 allocs/op
BenchmarkPathTrieGetStringKey-8   	39880358	        29.80 ns/op	       0 B/op	       0 allocs/op
BenchmarkPathTriePutPathKey-8     	17097781	        69.07 ns/op	       8 B/op	       1 allocs/op
BenchmarkPathTrieGetPathKey-8     	19641246	        61.73 ns/op	       0 B/op	       0 allocs/op
BenchmarkPathSegmenter-8          	44727998	        26.20 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/dghubble/trie	18.609s
```